### PR TITLE
Add payload.de Ethereum RPC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Checkout: [chainstack.com](https://chainstack.com/)
 - [https://eth-mainnet.rpcfast.com](https://eth-mainnet.rpcfast.com)
 - [https://1rpc.io/eth](https://1rpc.io/eth)
 - [https://ethereum.publicnode.com/](https://ethereum.publicnode.com/)
+- [https://rpc.payload.de](https://rpc.payload.de)
 
 **Spin up your own node:**
 


### PR DESCRIPTION
Added the payload.de RPC endpoint to the Ethereum node list. Payload.de is our new block builder, we have started at the beginning of this year. The RPC endpoint supports the default `eth` & `net` APIs. Sent transactions are private and included when building blocks.

Docs: https://payload.de/docs/
Privacy Policy: https://payload.de/privacy/