### PR TITLE
Add Infura to multichain providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ You can see the list of supported chains [here](https://getblock.io/nodes/).
 
 Checkout: [https://getblock.io/](https://getblock.io/)
 
+### Infura 
+
+Infura helps you build multichain applications by providing reliable and consistent RPC access to 10+ blockchain networks, including Ethereum, Polygon, Avalanche, NEAR, Celo, Aurora, StarkNet, Optimism, and Arbitrum. You can see all the chains Infura supports on the [Networks page](https://www.infura.io/networks). 
+
+With Infura, you’ll have access to the tools and infrastructure you need to “buidl” great dapps. This includes the IPFS API and Infura's [NFT API + SDK](https://www.infura.io/platform/nft-api) (for building NFTs), [free archival data access](https://www.infura.io/solutions/archive-access) to improve business analytics and audit historical on-chain data, as well as tools like Truffle, Ganache, and MetaMask to streamline web3 development. 
+
+[Sign up for a free Infura account](https://app.infura.io/register) today to join other developers and enterprise teams building web3 applications with Infura’s scalable, battle-tested, and easy-to-integrate blockchain APIs. 
+
 ## Account Abstraction RPC Providers
 
 **Providers**


### PR DESCRIPTION
This PR adds Infura to the list of web3 infrastructure providers with multichain support.